### PR TITLE
Unable to check message signature ref #31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- [\#23](https://github.com/skycoin/hardware-wallet-go/issues/23)
-
+  - Change protobuf messages for check signature to be consistent with [harware-wallet](https://github.com/skycoin/hardware-wallet/blob/2648cf384b5455c994ba54acf6a31cd1272c6f66/tiny-firmware/protob/messages.options#L21).
   - Mnemonic and recovery functions support `--wordCount` argument for the seed size (default `12`) .
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-  - Change protobuf messages for check signature to be consistent with [harware-wallet](https://github.com/skycoin/hardware-wallet/blob/2648cf384b5455c994ba54acf6a31cd1272c6f66/tiny-firmware/protob/messages.options#L21).
   - Mnemonic and recovery functions support `--wordCount` argument for the seed size (default `12`) .
 
 ### Fixed
+
+  - Change protobuf messages for check signature to be consistent with [harware-wallet](https://github.com/skycoin/hardware-wallet/blob/2648cf384b5455c994ba54acf6a31cd1272c6f66/tiny-firmware/protob/messages.options#L21).
 
 ### Changed
 

--- a/device-wallet/messages/messages.options
+++ b/device-wallet/messages/messages.options
@@ -22,9 +22,10 @@ ResponseSkycoinAddress.addresses				max_size:36, max_count:100
 // signed_message with ecdsa algoritm have a length of 65 bytes, in hex format this is 130
 ResponseSkycoinSignMessage.signed_message		max_size:130
 SkycoinCheckMessageSignature.address			max_size:36
-SkycoinCheckMessageSignature.message			max_size:256
-SkycoinCheckMessageSignature.signature			max_size:90
-SkycoinSignMessage.message			            max_size:256
+SkycoinCheckMessageSignature.message			max_size:66
+// signed_message with ecdsa algoritm have a length of 65 bytes, in hex format this is 130
+SkycoinCheckMessageSignature.signature			max_size:131
+SkycoinSignMessage.message			            max_size:131
 TransactionSign.transactionIn					max_count:8
 TransactionSign.transactionOut					max_count:8
 ResponseTransactionSign.signatures				max_size:90, max_count:8


### PR DESCRIPTION
Fixes #31

Changes:
- - Change protobuf messages for check signature to be consistent with [harware-wallet](https://github.com/skycoin/hardware-wallet/blob/2648cf384b5455c994ba54acf6a31cd1272c6f66/tiny-firmware/protob/messages.options#L21).

Does this change need to mentioned in CHANGELOG.md?
yes

Requires testing
no