### PR TITLE
[ci] refs #42 - Add os=osx in Travis matrix builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ go:
 matrix:
   include:
     - os: linux
+    - os: osx
 env:
   - PROTOC_VERSION=3.6.1 PROTOC_ZIP="protoc-$PROTOC_VERSION-$TRAVIS_OS_NAME-x86_64.zip" PROTOC_URL="https://github.com/google/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_ZIP"
 before_install:
-  - sudo apt-get update
-  - sudo apt install libudev-dev libusb-1.0-0-dev
+  - source ./ci-scripts/install-$TRAVIS_OS_NAME.sh
   - echo "Downloading protobuf from $PROTOC_URL"
   - curl -OL $PROTOC_URL
   - sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc

--- a/ci-scripts/install-linux.sh
+++ b/ci-scripts/install-linux.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+sudo apt-get update
+sudo apt install libudev-dev libusb-1.0-0-dev
+

--- a/ci-scripts/install-osx.sh
+++ b/ci-scripts/install-osx.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+brew install libusb
+


### PR DESCRIPTION
Fixes #42

Changes:
- Travis builds for osx
- Install packages through homebrew

Does this change need to mentioned in CHANGELOG.md?
no

Requires testing
no
