### PR TITLE
resent generate mnemonic after a entropy ack required by a generate mnemonic msg ref #73

### DIFF
--- a/src/device-wallet/device-wallet.go
+++ b/src/device-wallet/device-wallet.go
@@ -316,18 +316,18 @@ func (d *Device) GenerateMnemonic(wordCount uint32, usePassphrase bool) (wire.Me
 		return wire.Message{}, err
 	}
 	defer dev.Close()
-	chunks, err := MessageGenerateMnemonic(wordCount, usePassphrase)
+	generateMnemonicChunks, err := MessageGenerateMnemonic(wordCount, usePassphrase)
 	if err != nil {
 		return wire.Message{}, err
 	}
-	msg, err := d.Driver.SendToDevice(dev, chunks)
+	msg, err := d.Driver.SendToDevice(dev, generateMnemonicChunks)
 	if err != nil {
 		return msg, err
 	}
 
 	switch msg.Kind {
 	case uint16(messages.MessageType_MessageType_ButtonRequest):
-		chunks, err = MessageButtonAck()
+		chunks, err := MessageButtonAck()
 		if err != nil {
 			return wire.Message{}, err
 		}
@@ -336,13 +336,17 @@ func (d *Device) GenerateMnemonic(wordCount uint32, usePassphrase bool) (wire.Me
 			return wire.Message{}, err
 		}
 	case uint16(messages.MessageType_MessageType_EntropyRequest):
-		chunks, err = MessageEntropyAck(entropyBufferSize)
+		chunks, err := MessageEntropyAck(entropyBufferSize)
 		if err != nil {
 			return wire.Message{}, err
 		}
 		msg, err = d.Driver.SendToDevice(dev, chunks)
 		if err != nil {
 			return wire.Message{}, err
+		}
+		msg, err = d.Driver.SendToDevice(dev, generateMnemonicChunks)
+		if err != nil {
+			return msg, err
 		}
 	}
 

--- a/src/device-wallet/device_wallet_test.go
+++ b/src/device-wallet/device_wallet_test.go
@@ -51,7 +51,7 @@ func (suite *devicerSuit) TestGenerateMnemonic() {
 	// NOTE(denisacostaq@gmail.com): Assert
 	suite.Nil(err)
 	driverMock.AssertCalled(suite.T(), "GetDevice")
-	driverMock.AssertNumberOfCalls(suite.T(), "SendToDevice", 2)
+	driverMock.AssertNumberOfCalls(suite.T(), "SendToDevice", 3)
 	mock.AssertExpectationsForObjects(suite.T(), driverMock)
 	spew.Dump(msg)
 }


### PR DESCRIPTION
Fixes #73 

Changes:
- send generate mnemonic msg, if receive a entropy request send it and resend the original generate mnemonic again

Does this change need to mentioned in CHANGELOG.md?
no

no
