### PR TITLE
Fixes #61 [device-wallet]  Rename addressN in SignMessage to addressIndex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 DS_Store
 
 vendor/github.com/google/protobuf/descriptor.pb.go
+
+#IDE
+.idea

--- a/src/device-wallet/device-wallet.go
+++ b/src/device-wallet/device-wallet.go
@@ -36,7 +36,7 @@ type Devicer interface {
 	Recovery(wordCount uint32, usePassphrase, dryRun bool) (wire.Message, error)
 	SetMnemonic(mnemonic string) (wire.Message, error)
 	TransactionSign(inputs []*messages.SkycoinTransactionInput, outputs []*messages.SkycoinTransactionOutput) (wire.Message, error)
-	SignMessage(addressN int, message string) (wire.Message, error)
+	SignMessage(addressIndex int, message string) (wire.Message, error)
 	Wipe() (wire.Message, error)
 	PinMatrixAck(p string) (wire.Message, error)
 	WordAck(word string) (wire.Message, error)
@@ -413,14 +413,14 @@ func (d *Device) SetMnemonic(mnemonic string) (wire.Message, error) {
 }
 
 // SignMessage Ask the device to sign a message using the secret key at given index.
-func (d *Device) SignMessage(addressN int, message string) (wire.Message, error) {
+func (d *Device) SignMessage(addressIndex int, message string) (wire.Message, error) {
 	dev, err := d.Driver.GetDevice()
 	if err != nil {
 		return wire.Message{}, err
 	}
 	defer dev.Close()
 
-	chunks, err := MessageSignMessage(addressN, message)
+	chunks, err := MessageSignMessage(addressIndex, message)
 	if err != nil {
 		return wire.Message{}, err
 	}

--- a/src/device-wallet/messages.go
+++ b/src/device-wallet/messages.go
@@ -232,9 +232,9 @@ func MessageSetMnemonic(mnemonic string) ([][64]byte, error) {
 }
 
 // MessageSignMessage prepare MessageSignMessage request
-func MessageSignMessage(addressN int, message string) ([][64]byte, error) {
+func MessageSignMessage(addressIndex int, message string) ([][64]byte, error) {
 	skycoinSignMessage := &messages.SkycoinSignMessage{
-		AddressN: proto.Uint32(uint32(addressN)),
+		AddressN: proto.Uint32(uint32(addressIndex)),
 		Message:  proto.String(message),
 	}
 


### PR DESCRIPTION
Fixes #61 

Changes:
- Rename addressN in SignMessage to addressIndex

Does this change need to mentioned in CHANGELOG.md?
no

Requires testing
no

