### PR TITLE
add lock to device connection

### DIFF
--- a/src/device-wallet/device-wallet.go
+++ b/src/device-wallet/device-wallet.go
@@ -117,6 +117,7 @@ func NewDevice(deviceType DeviceType) (device *Device) {
 func (d *Device) Connect() error {
 	// close any existing connections
 	connLock.Lock()
+	defer connLock.Unlock()
 	if d.dev != nil {
 		d.dev.Close()
 		d.dev = nil
@@ -128,7 +129,6 @@ func (d *Device) Connect() error {
 	}
 
 	d.dev = dev
-	connLock.Unlock()
 	return nil
 }
 

--- a/src/device-wallet/device-wallet.go
+++ b/src/device-wallet/device-wallet.go
@@ -121,14 +121,12 @@ func (d *Device) Connect() error {
 		d.dev.Close()
 		d.dev = nil
 	}
-	connLock.Unlock()
 
 	dev, err := d.Driver.GetDevice()
 	if err != nil {
 		return err
 	}
 
-	connLock.Lock()
 	d.dev = dev
 	connLock.Unlock()
 	return nil

--- a/src/device-wallet/device-wallet.go
+++ b/src/device-wallet/device-wallet.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/skycoin/hardware-wallet-go/src/device-wallet/usb"
@@ -71,6 +72,7 @@ type Device struct {
 	// dev latest device connection instance
 	// during an ongoing operation the device instance cannot be requested before closing the previous instance
 	// keeping the connection instance in the struct helps with closing and opening of the connection
+	sync.RWMutex
 	dev io.ReadWriteCloser
 
 	simulateButtonPress bool
@@ -100,6 +102,7 @@ func NewDevice(deviceType DeviceType) (device *Device) {
 	case DeviceTypeUSB, DeviceTypeEmulator:
 		device = &Device{
 			&Driver{deviceType},
+			sync.RWMutex{},
 			nil,
 			false,
 			ButtonType(-1),
@@ -113,17 +116,21 @@ func NewDevice(deviceType DeviceType) (device *Device) {
 // Connect makes a connection to the connected device
 func (d *Device) Connect() error {
 	// close any existing connections
+	d.RLock()
 	if d.dev != nil {
 		d.dev.Close()
 		d.dev = nil
 	}
+	d.RUnlock()
 
 	dev, err := d.Driver.GetDevice()
 	if err != nil {
 		return err
 	}
 
+	d.Lock()
 	d.dev = dev
+	d.Unlock()
 	return nil
 }
 

--- a/src/device-wallet/device_wallet_test.go
+++ b/src/device-wallet/device_wallet_test.go
@@ -2,6 +2,7 @@ package devicewallet
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -44,7 +45,7 @@ func (suite *devicerSuit) TestGenerateMnemonic() {
 	driverMock.On("GetDevice").Return(&testHelperCloseableBuffer{}, nil)
 	driverMock.On("SendToDevice", mock.Anything, mock.Anything).Return(
 		wire.Message{Kind: uint16(messages.MessageType_MessageType_EntropyRequest), Data: nil}, nil)
-	device := Device{driverMock, nil, false, ButtonType(-1)}
+	device := Device{driverMock, sync.RWMutex{}, nil, false, ButtonType(-1)}
 
 	// NOTE(denisacostaq@gmail.com): When
 	msg, err := device.GenerateMnemonic(12, false)

--- a/src/device-wallet/device_wallet_test.go
+++ b/src/device-wallet/device_wallet_test.go
@@ -2,7 +2,6 @@ package devicewallet
 
 import (
 	"bytes"
-	"sync"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -45,7 +44,7 @@ func (suite *devicerSuit) TestGenerateMnemonic() {
 	driverMock.On("GetDevice").Return(&testHelperCloseableBuffer{}, nil)
 	driverMock.On("SendToDevice", mock.Anything, mock.Anything).Return(
 		wire.Message{Kind: uint16(messages.MessageType_MessageType_EntropyRequest), Data: nil}, nil)
-	device := Device{driverMock, sync.RWMutex{}, nil, false, ButtonType(-1)}
+	device := Device{driverMock, nil, false, ButtonType(-1)}
 
 	// NOTE(denisacostaq@gmail.com): When
 	msg, err := device.GenerateMnemonic(12, false)


### PR DESCRIPTION
Related to #https://github.com/skycoin/hardware-wallet-daemon/issues/44

Changes:
- Add a lock to `Device` struct to prevent race conditions in daemon

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no

Requires testing
no

