### PR TITLE
fix messages collision ref #148

### DIFF
--- a/src/skywallet/helper.go
+++ b/src/skywallet/helper.go
@@ -288,18 +288,25 @@ func DecodeSuccessOrFailMsg(msg wire.Message) (string, error) {
 	return "", fmt.Errorf("calling DecodeSuccessOrFailMsg on message kind %s", messages.MessageType(msg.Kind))
 }
 
+func decodeSuccessMsgStruct(msg wire.Message) (messages.Success, error) {
+	if msg.Kind == uint16(messages.MessageType_MessageType_Success) {
+		success := messages.Success{}
+		err := proto.Unmarshal(msg.Data, &success)
+		if err != nil {
+			return messages.Success{}, err
+		}
+		return success, nil
+	}
+	return messages.Success{}, fmt.Errorf("calling DecodeSuccessMsg with wrong message type: %s", messages.MessageType(msg.Kind))
+}
+
 // DecodeSuccessMsg convert byte data into string containing the success message returned by the device
 func DecodeSuccessMsg(msg wire.Message) (string, error) {
-	if msg.Kind == uint16(messages.MessageType_MessageType_Success) {
-		success := &messages.Success{}
-		err := proto.Unmarshal(msg.Data, success)
-		if err != nil {
-			return "", err
-		}
-		return success.GetMessage(), nil
+	success, err := decodeSuccessMsgStruct(msg)
+	if err != nil {
+		return "", err
 	}
-
-	return "", fmt.Errorf("calling DecodeSuccessMsg with wrong message type: %s", messages.MessageType(msg.Kind))
+	return success.GetMessage(), nil
 }
 
 // DecodeFailMsg convert byte data into string containing the failure returned by the device

--- a/src/skywallet/helper.go
+++ b/src/skywallet/helper.go
@@ -229,6 +229,20 @@ func sendToDevice(dev usb.Device, chunks [][64]byte) (wire.Message, error) {
 		}
 		wg.Wait()
 	}
+	for msg.Kind == uint16(messages.MessageType_MessageType_Success) {
+		success, err := decodeSuccessMsgStruct(*msg)
+		if err != nil {
+			return wire.Message{}, err
+		}
+		if success.MsgType != nil && *success.MsgType == messages.MessageType(messages.MessageType_MessageType_EntropyAck) {
+			msg, err = wire.ReadFrom(dev)
+			if err != nil {
+				return wire.Message{}, err
+			}
+		} else {
+			break
+		}
+	}
 
 	return *msg, err
 }

--- a/vendor/github.com/skycoin/hardware-wallet-protob/go/google/protobuf/descriptor.pb.go
+++ b/vendor/github.com/skycoin/hardware-wallet-protob/go/google/protobuf/descriptor.pb.go
@@ -106,7 +106,7 @@ func (x *FieldDescriptorProto_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (FieldDescriptorProto_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{3, 0}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{3, 0}
 }
 
 type FieldDescriptorProto_Label int32
@@ -146,7 +146,7 @@ func (x *FieldDescriptorProto_Label) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (FieldDescriptorProto_Label) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{3, 1}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{3, 1}
 }
 
 // Generated classes can be optimized for speed or code size.
@@ -187,7 +187,7 @@ func (x *FileOptions_OptimizeMode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (FileOptions_OptimizeMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{9, 0}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{9, 0}
 }
 
 type FieldOptions_CType int32
@@ -227,7 +227,7 @@ func (x *FieldOptions_CType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (FieldOptions_CType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{11, 0}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{11, 0}
 }
 
 // The protocol compiler can output a FileDescriptorSet containing the .proto
@@ -243,7 +243,7 @@ func (m *FileDescriptorSet) Reset()         { *m = FileDescriptorSet{} }
 func (m *FileDescriptorSet) String() string { return proto.CompactTextString(m) }
 func (*FileDescriptorSet) ProtoMessage()    {}
 func (*FileDescriptorSet) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{0}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{0}
 }
 func (m *FileDescriptorSet) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FileDescriptorSet.Unmarshal(m, b)
@@ -304,7 +304,7 @@ func (m *FileDescriptorProto) Reset()         { *m = FileDescriptorProto{} }
 func (m *FileDescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*FileDescriptorProto) ProtoMessage()    {}
 func (*FileDescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{1}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{1}
 }
 func (m *FileDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FileDescriptorProto.Unmarshal(m, b)
@@ -427,7 +427,7 @@ func (m *DescriptorProto) Reset()         { *m = DescriptorProto{} }
 func (m *DescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*DescriptorProto) ProtoMessage()    {}
 func (*DescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{2}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{2}
 }
 func (m *DescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DescriptorProto.Unmarshal(m, b)
@@ -515,7 +515,7 @@ func (m *DescriptorProto_ExtensionRange) Reset()         { *m = DescriptorProto_
 func (m *DescriptorProto_ExtensionRange) String() string { return proto.CompactTextString(m) }
 func (*DescriptorProto_ExtensionRange) ProtoMessage()    {}
 func (*DescriptorProto_ExtensionRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{2, 0}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{2, 0}
 }
 func (m *DescriptorProto_ExtensionRange) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DescriptorProto_ExtensionRange.Unmarshal(m, b)
@@ -587,7 +587,7 @@ func (m *FieldDescriptorProto) Reset()         { *m = FieldDescriptorProto{} }
 func (m *FieldDescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*FieldDescriptorProto) ProtoMessage()    {}
 func (*FieldDescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{3}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{3}
 }
 func (m *FieldDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FieldDescriptorProto.Unmarshal(m, b)
@@ -682,7 +682,7 @@ func (m *OneofDescriptorProto) Reset()         { *m = OneofDescriptorProto{} }
 func (m *OneofDescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*OneofDescriptorProto) ProtoMessage()    {}
 func (*OneofDescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{4}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{4}
 }
 func (m *OneofDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OneofDescriptorProto.Unmarshal(m, b)
@@ -723,7 +723,7 @@ func (m *EnumDescriptorProto) Reset()         { *m = EnumDescriptorProto{} }
 func (m *EnumDescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*EnumDescriptorProto) ProtoMessage()    {}
 func (*EnumDescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{5}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{5}
 }
 func (m *EnumDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EnumDescriptorProto.Unmarshal(m, b)
@@ -778,7 +778,7 @@ func (m *EnumValueDescriptorProto) Reset()         { *m = EnumValueDescriptorPro
 func (m *EnumValueDescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*EnumValueDescriptorProto) ProtoMessage()    {}
 func (*EnumValueDescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{6}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{6}
 }
 func (m *EnumValueDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EnumValueDescriptorProto.Unmarshal(m, b)
@@ -833,7 +833,7 @@ func (m *ServiceDescriptorProto) Reset()         { *m = ServiceDescriptorProto{}
 func (m *ServiceDescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*ServiceDescriptorProto) ProtoMessage()    {}
 func (*ServiceDescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{7}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{7}
 }
 func (m *ServiceDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ServiceDescriptorProto.Unmarshal(m, b)
@@ -895,7 +895,7 @@ func (m *MethodDescriptorProto) Reset()         { *m = MethodDescriptorProto{} }
 func (m *MethodDescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*MethodDescriptorProto) ProtoMessage()    {}
 func (*MethodDescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{8}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{8}
 }
 func (m *MethodDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MethodDescriptorProto.Unmarshal(m, b)
@@ -1037,7 +1037,7 @@ func (m *FileOptions) Reset()         { *m = FileOptions{} }
 func (m *FileOptions) String() string { return proto.CompactTextString(m) }
 func (*FileOptions) ProtoMessage()    {}
 func (*FileOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{9}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{9}
 }
 
 var extRange_FileOptions = []proto.ExtensionRange{
@@ -1229,7 +1229,7 @@ func (m *MessageOptions) Reset()         { *m = MessageOptions{} }
 func (m *MessageOptions) String() string { return proto.CompactTextString(m) }
 func (*MessageOptions) ProtoMessage()    {}
 func (*MessageOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{10}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{10}
 }
 
 var extRange_MessageOptions = []proto.ExtensionRange{
@@ -1355,7 +1355,7 @@ func (m *FieldOptions) Reset()         { *m = FieldOptions{} }
 func (m *FieldOptions) String() string { return proto.CompactTextString(m) }
 func (*FieldOptions) ProtoMessage()    {}
 func (*FieldOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{11}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{11}
 }
 
 var extRange_FieldOptions = []proto.ExtensionRange{
@@ -1451,7 +1451,7 @@ func (m *EnumOptions) Reset()         { *m = EnumOptions{} }
 func (m *EnumOptions) String() string { return proto.CompactTextString(m) }
 func (*EnumOptions) ProtoMessage()    {}
 func (*EnumOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{12}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{12}
 }
 
 var extRange_EnumOptions = []proto.ExtensionRange{
@@ -1520,7 +1520,7 @@ func (m *EnumValueOptions) Reset()         { *m = EnumValueOptions{} }
 func (m *EnumValueOptions) String() string { return proto.CompactTextString(m) }
 func (*EnumValueOptions) ProtoMessage()    {}
 func (*EnumValueOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{13}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{13}
 }
 
 var extRange_EnumValueOptions = []proto.ExtensionRange{
@@ -1582,7 +1582,7 @@ func (m *ServiceOptions) Reset()         { *m = ServiceOptions{} }
 func (m *ServiceOptions) String() string { return proto.CompactTextString(m) }
 func (*ServiceOptions) ProtoMessage()    {}
 func (*ServiceOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{14}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{14}
 }
 
 var extRange_ServiceOptions = []proto.ExtensionRange{
@@ -1644,7 +1644,7 @@ func (m *MethodOptions) Reset()         { *m = MethodOptions{} }
 func (m *MethodOptions) String() string { return proto.CompactTextString(m) }
 func (*MethodOptions) ProtoMessage()    {}
 func (*MethodOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{15}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{15}
 }
 
 var extRange_MethodOptions = []proto.ExtensionRange{
@@ -1713,7 +1713,7 @@ func (m *UninterpretedOption) Reset()         { *m = UninterpretedOption{} }
 func (m *UninterpretedOption) String() string { return proto.CompactTextString(m) }
 func (*UninterpretedOption) ProtoMessage()    {}
 func (*UninterpretedOption) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{16}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{16}
 }
 func (m *UninterpretedOption) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UninterpretedOption.Unmarshal(m, b)
@@ -1799,7 +1799,7 @@ func (m *UninterpretedOption_NamePart) Reset()         { *m = UninterpretedOptio
 func (m *UninterpretedOption_NamePart) String() string { return proto.CompactTextString(m) }
 func (*UninterpretedOption_NamePart) ProtoMessage()    {}
 func (*UninterpretedOption_NamePart) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{16, 0}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{16, 0}
 }
 func (m *UninterpretedOption_NamePart) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UninterpretedOption_NamePart.Unmarshal(m, b)
@@ -1889,7 +1889,7 @@ func (m *SourceCodeInfo) Reset()         { *m = SourceCodeInfo{} }
 func (m *SourceCodeInfo) String() string { return proto.CompactTextString(m) }
 func (*SourceCodeInfo) ProtoMessage()    {}
 func (*SourceCodeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{17}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{17}
 }
 func (m *SourceCodeInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SourceCodeInfo.Unmarshal(m, b)
@@ -1992,7 +1992,7 @@ func (m *SourceCodeInfo_Location) Reset()         { *m = SourceCodeInfo_Location
 func (m *SourceCodeInfo_Location) String() string { return proto.CompactTextString(m) }
 func (*SourceCodeInfo_Location) ProtoMessage()    {}
 func (*SourceCodeInfo_Location) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_41f73bbb1bd821d5, []int{17, 0}
+	return fileDescriptor_descriptor_1315903dacfcb8f9, []int{17, 0}
 }
 func (m *SourceCodeInfo_Location) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SourceCodeInfo_Location.Unmarshal(m, b)
@@ -2069,10 +2069,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("google/protobuf/descriptor.proto", fileDescriptor_descriptor_41f73bbb1bd821d5)
+	proto.RegisterFile("google/protobuf/descriptor.proto", fileDescriptor_descriptor_1315903dacfcb8f9)
 }
 
-var fileDescriptor_descriptor_41f73bbb1bd821d5 = []byte{
+var fileDescriptor_descriptor_1315903dacfcb8f9 = []byte{
 	// 1981 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x58, 0x4f, 0x73, 0x1b, 0x49,
 	0x15, 0x67, 0xf4, 0xcf, 0xd2, 0x93, 0x2c, 0xb7, 0xdb, 0x5e, 0xef, 0x24, 0xd9, 0x6c, 0x6c, 0x2d,

--- a/vendor/github.com/skycoin/hardware-wallet-protob/go/messages.pb.go
+++ b/vendor/github.com/skycoin/hardware-wallet-protob/go/messages.pb.go
@@ -172,7 +172,7 @@ func (x *MessageType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (MessageType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{0}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{0}
 }
 
 // *
@@ -189,7 +189,7 @@ func (m *Initialize) Reset()         { *m = Initialize{} }
 func (m *Initialize) String() string { return proto.CompactTextString(m) }
 func (*Initialize) ProtoMessage()    {}
 func (*Initialize) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{0}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{0}
 }
 func (m *Initialize) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -238,7 +238,7 @@ func (m *GetFeatures) Reset()         { *m = GetFeatures{} }
 func (m *GetFeatures) String() string { return proto.CompactTextString(m) }
 func (*GetFeatures) ProtoMessage()    {}
 func (*GetFeatures) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{1}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{1}
 }
 func (m *GetFeatures) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -306,7 +306,7 @@ func (m *Features) Reset()         { *m = Features{} }
 func (m *Features) String() string { return proto.CompactTextString(m) }
 func (*Features) ProtoMessage()    {}
 func (*Features) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{2}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{2}
 }
 func (m *Features) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -529,7 +529,7 @@ func (m *ApplySettings) Reset()         { *m = ApplySettings{} }
 func (m *ApplySettings) String() string { return proto.CompactTextString(m) }
 func (*ApplySettings) ProtoMessage()    {}
 func (*ApplySettings) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{3}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{3}
 }
 func (m *ApplySettings) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -601,7 +601,7 @@ func (m *GenerateMnemonic) Reset()         { *m = GenerateMnemonic{} }
 func (m *GenerateMnemonic) String() string { return proto.CompactTextString(m) }
 func (*GenerateMnemonic) ProtoMessage()    {}
 func (*GenerateMnemonic) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{4}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{4}
 }
 func (m *GenerateMnemonic) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -658,7 +658,7 @@ func (m *SetMnemonic) Reset()         { *m = SetMnemonic{} }
 func (m *SetMnemonic) String() string { return proto.CompactTextString(m) }
 func (*SetMnemonic) ProtoMessage()    {}
 func (*SetMnemonic) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{5}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{5}
 }
 func (m *SetMnemonic) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -709,7 +709,7 @@ func (m *ChangePin) Reset()         { *m = ChangePin{} }
 func (m *ChangePin) String() string { return proto.CompactTextString(m) }
 func (*ChangePin) ProtoMessage()    {}
 func (*ChangePin) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{6}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{6}
 }
 func (m *ChangePin) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -762,7 +762,7 @@ func (m *SkycoinAddress) Reset()         { *m = SkycoinAddress{} }
 func (m *SkycoinAddress) String() string { return proto.CompactTextString(m) }
 func (*SkycoinAddress) ProtoMessage()    {}
 func (*SkycoinAddress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{7}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{7}
 }
 func (m *SkycoinAddress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -826,7 +826,7 @@ func (m *ResponseSkycoinAddress) Reset()         { *m = ResponseSkycoinAddress{}
 func (m *ResponseSkycoinAddress) String() string { return proto.CompactTextString(m) }
 func (*ResponseSkycoinAddress) ProtoMessage()    {}
 func (*ResponseSkycoinAddress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{8}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{8}
 }
 func (m *ResponseSkycoinAddress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -877,7 +877,7 @@ func (m *ResponseTransactionSign) Reset()         { *m = ResponseTransactionSign
 func (m *ResponseTransactionSign) String() string { return proto.CompactTextString(m) }
 func (*ResponseTransactionSign) ProtoMessage()    {}
 func (*ResponseTransactionSign) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{9}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{9}
 }
 func (m *ResponseTransactionSign) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -936,7 +936,7 @@ func (m *SkycoinCheckMessageSignature) Reset()         { *m = SkycoinCheckMessag
 func (m *SkycoinCheckMessageSignature) String() string { return proto.CompactTextString(m) }
 func (*SkycoinCheckMessageSignature) ProtoMessage()    {}
 func (*SkycoinCheckMessageSignature) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{10}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{10}
 }
 func (m *SkycoinCheckMessageSignature) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1002,7 +1002,7 @@ func (m *SkycoinSignMessage) Reset()         { *m = SkycoinSignMessage{} }
 func (m *SkycoinSignMessage) String() string { return proto.CompactTextString(m) }
 func (*SkycoinSignMessage) ProtoMessage()    {}
 func (*SkycoinSignMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{11}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{11}
 }
 func (m *SkycoinSignMessage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1059,7 +1059,7 @@ func (m *ResponseSkycoinSignMessage) Reset()         { *m = ResponseSkycoinSignM
 func (m *ResponseSkycoinSignMessage) String() string { return proto.CompactTextString(m) }
 func (*ResponseSkycoinSignMessage) ProtoMessage()    {}
 func (*ResponseSkycoinSignMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{12}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{12}
 }
 func (m *ResponseSkycoinSignMessage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1112,7 +1112,7 @@ func (m *Ping) Reset()         { *m = Ping{} }
 func (m *Ping) String() string { return proto.CompactTextString(m) }
 func (*Ping) ProtoMessage()    {}
 func (*Ping) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{13}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{13}
 }
 func (m *Ping) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1183,7 +1183,7 @@ func (m *Success) Reset()         { *m = Success{} }
 func (m *Success) String() string { return proto.CompactTextString(m) }
 func (*Success) ProtoMessage()    {}
 func (*Success) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{14}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{14}
 }
 func (m *Success) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1241,7 +1241,7 @@ func (m *Failure) Reset()         { *m = Failure{} }
 func (m *Failure) String() string { return proto.CompactTextString(m) }
 func (*Failure) ProtoMessage()    {}
 func (*Failure) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{15}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{15}
 }
 func (m *Failure) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1307,7 +1307,7 @@ func (m *ButtonRequest) Reset()         { *m = ButtonRequest{} }
 func (m *ButtonRequest) String() string { return proto.CompactTextString(m) }
 func (*ButtonRequest) ProtoMessage()    {}
 func (*ButtonRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{16}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{16}
 }
 func (m *ButtonRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1363,7 +1363,7 @@ func (m *ButtonAck) Reset()         { *m = ButtonAck{} }
 func (m *ButtonAck) String() string { return proto.CompactTextString(m) }
 func (*ButtonAck) ProtoMessage()    {}
 func (*ButtonAck) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{17}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{17}
 }
 func (m *ButtonAck) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1407,7 +1407,7 @@ func (m *PinMatrixRequest) Reset()         { *m = PinMatrixRequest{} }
 func (m *PinMatrixRequest) String() string { return proto.CompactTextString(m) }
 func (*PinMatrixRequest) ProtoMessage()    {}
 func (*PinMatrixRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{18}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{18}
 }
 func (m *PinMatrixRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1457,7 +1457,7 @@ func (m *PinMatrixAck) Reset()         { *m = PinMatrixAck{} }
 func (m *PinMatrixAck) String() string { return proto.CompactTextString(m) }
 func (*PinMatrixAck) ProtoMessage()    {}
 func (*PinMatrixAck) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{19}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{19}
 }
 func (m *PinMatrixAck) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1508,7 +1508,7 @@ func (m *Cancel) Reset()         { *m = Cancel{} }
 func (m *Cancel) String() string { return proto.CompactTextString(m) }
 func (*Cancel) ProtoMessage()    {}
 func (*Cancel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{20}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{20}
 }
 func (m *Cancel) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1552,7 +1552,7 @@ func (m *PassphraseRequest) Reset()         { *m = PassphraseRequest{} }
 func (m *PassphraseRequest) String() string { return proto.CompactTextString(m) }
 func (*PassphraseRequest) ProtoMessage()    {}
 func (*PassphraseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{21}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{21}
 }
 func (m *PassphraseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1604,7 +1604,7 @@ func (m *PassphraseAck) Reset()         { *m = PassphraseAck{} }
 func (m *PassphraseAck) String() string { return proto.CompactTextString(m) }
 func (*PassphraseAck) ProtoMessage()    {}
 func (*PassphraseAck) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{22}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{22}
 }
 func (m *PassphraseAck) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1661,7 +1661,7 @@ func (m *PassphraseStateRequest) Reset()         { *m = PassphraseStateRequest{}
 func (m *PassphraseStateRequest) String() string { return proto.CompactTextString(m) }
 func (*PassphraseStateRequest) ProtoMessage()    {}
 func (*PassphraseStateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{23}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{23}
 }
 func (m *PassphraseStateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1709,7 +1709,7 @@ func (m *PassphraseStateAck) Reset()         { *m = PassphraseStateAck{} }
 func (m *PassphraseStateAck) String() string { return proto.CompactTextString(m) }
 func (*PassphraseStateAck) ProtoMessage()    {}
 func (*PassphraseStateAck) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{24}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{24}
 }
 func (m *PassphraseStateAck) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1754,7 +1754,7 @@ func (m *GetRawEntropy) Reset()         { *m = GetRawEntropy{} }
 func (m *GetRawEntropy) String() string { return proto.CompactTextString(m) }
 func (*GetRawEntropy) ProtoMessage()    {}
 func (*GetRawEntropy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{25}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{25}
 }
 func (m *GetRawEntropy) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1806,7 +1806,7 @@ func (m *GetMixedEntropy) Reset()         { *m = GetMixedEntropy{} }
 func (m *GetMixedEntropy) String() string { return proto.CompactTextString(m) }
 func (*GetMixedEntropy) ProtoMessage()    {}
 func (*GetMixedEntropy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{26}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{26}
 }
 func (m *GetMixedEntropy) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1857,7 +1857,7 @@ func (m *Entropy) Reset()         { *m = Entropy{} }
 func (m *Entropy) String() string { return proto.CompactTextString(m) }
 func (*Entropy) ProtoMessage()    {}
 func (*Entropy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{27}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{27}
 }
 func (m *Entropy) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1906,7 +1906,7 @@ func (m *WipeDevice) Reset()         { *m = WipeDevice{} }
 func (m *WipeDevice) String() string { return proto.CompactTextString(m) }
 func (*WipeDevice) ProtoMessage()    {}
 func (*WipeDevice) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{28}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{28}
 }
 func (m *WipeDevice) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1958,7 +1958,7 @@ func (m *LoadDevice) Reset()         { *m = LoadDevice{} }
 func (m *LoadDevice) String() string { return proto.CompactTextString(m) }
 func (*LoadDevice) ProtoMessage()    {}
 func (*LoadDevice) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{29}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{29}
 }
 func (m *LoadDevice) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2067,7 +2067,7 @@ func (m *ResetDevice) Reset()         { *m = ResetDevice{} }
 func (m *ResetDevice) String() string { return proto.CompactTextString(m) }
 func (*ResetDevice) ProtoMessage()    {}
 func (*ResetDevice) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{30}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{30}
 }
 func (m *ResetDevice) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2168,7 +2168,7 @@ func (m *BackupDevice) Reset()         { *m = BackupDevice{} }
 func (m *BackupDevice) String() string { return proto.CompactTextString(m) }
 func (*BackupDevice) ProtoMessage()    {}
 func (*BackupDevice) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{31}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{31}
 }
 func (m *BackupDevice) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2211,7 +2211,7 @@ func (m *EntropyRequest) Reset()         { *m = EntropyRequest{} }
 func (m *EntropyRequest) String() string { return proto.CompactTextString(m) }
 func (*EntropyRequest) ProtoMessage()    {}
 func (*EntropyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{32}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{32}
 }
 func (m *EntropyRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2255,7 +2255,7 @@ func (m *EntropyAck) Reset()         { *m = EntropyAck{} }
 func (m *EntropyAck) String() string { return proto.CompactTextString(m) }
 func (*EntropyAck) ProtoMessage()    {}
 func (*EntropyAck) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{33}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{33}
 }
 func (m *EntropyAck) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2311,7 +2311,7 @@ func (m *RecoveryDevice) Reset()         { *m = RecoveryDevice{} }
 func (m *RecoveryDevice) String() string { return proto.CompactTextString(m) }
 func (*RecoveryDevice) ProtoMessage()    {}
 func (*RecoveryDevice) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{34}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{34}
 }
 func (m *RecoveryDevice) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2400,7 +2400,7 @@ func (m *WordRequest) Reset()         { *m = WordRequest{} }
 func (m *WordRequest) String() string { return proto.CompactTextString(m) }
 func (*WordRequest) ProtoMessage()    {}
 func (*WordRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{35}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{35}
 }
 func (m *WordRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2453,7 +2453,7 @@ func (m *WordAck) Reset()         { *m = WordAck{} }
 func (m *WordAck) String() string { return proto.CompactTextString(m) }
 func (*WordAck) ProtoMessage()    {}
 func (*WordAck) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{36}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{36}
 }
 func (m *WordAck) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2504,7 +2504,7 @@ func (m *FirmwareErase) Reset()         { *m = FirmwareErase{} }
 func (m *FirmwareErase) String() string { return proto.CompactTextString(m) }
 func (*FirmwareErase) ProtoMessage()    {}
 func (*FirmwareErase) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{37}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{37}
 }
 func (m *FirmwareErase) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2555,7 +2555,7 @@ func (m *FirmwareRequest) Reset()         { *m = FirmwareRequest{} }
 func (m *FirmwareRequest) String() string { return proto.CompactTextString(m) }
 func (*FirmwareRequest) ProtoMessage()    {}
 func (*FirmwareRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{38}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{38}
 }
 func (m *FirmwareRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2614,7 +2614,7 @@ func (m *FirmwareUpload) Reset()         { *m = FirmwareUpload{} }
 func (m *FirmwareUpload) String() string { return proto.CompactTextString(m) }
 func (*FirmwareUpload) ProtoMessage()    {}
 func (*FirmwareUpload) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{39}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{39}
 }
 func (m *FirmwareUpload) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2676,7 +2676,7 @@ func (m *TransactionSign) Reset()         { *m = TransactionSign{} }
 func (m *TransactionSign) String() string { return proto.CompactTextString(m) }
 func (*TransactionSign) ProtoMessage()    {}
 func (*TransactionSign) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_dc38627d46042ff4, []int{40}
+	return fileDescriptor_messages_bbde4920d2a44384, []int{40}
 }
 func (m *TransactionSign) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -10039,9 +10039,9 @@ var (
 	ErrIntOverflowMessages   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("messages.proto", fileDescriptor_messages_dc38627d46042ff4) }
+func init() { proto.RegisterFile("messages.proto", fileDescriptor_messages_bbde4920d2a44384) }
 
-var fileDescriptor_messages_dc38627d46042ff4 = []byte{
+var fileDescriptor_messages_bbde4920d2a44384 = []byte{
 	// 2046 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x58, 0x4f, 0x73, 0xdb, 0xc6,
 	0x15, 0x2f, 0x48, 0x5a, 0x24, 0x1f, 0x09, 0x6a, 0x05, 0xdb, 0x32, 0x4c, 0x4b, 0x32, 0x03, 0x5a,

--- a/vendor/github.com/skycoin/hardware-wallet-protob/go/types.pb.go
+++ b/vendor/github.com/skycoin/hardware-wallet-protob/go/types.pb.go
@@ -98,7 +98,7 @@ func (x *FailureType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (FailureType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{0}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{0}
 }
 
 // *
@@ -149,7 +149,7 @@ func (x *OutputScriptType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (OutputScriptType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{1}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{1}
 }
 
 // *
@@ -197,7 +197,7 @@ func (x *InputScriptType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (InputScriptType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{2}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{2}
 }
 
 // *
@@ -245,7 +245,7 @@ func (x *RequestType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (RequestType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{3}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{3}
 }
 
 // *
@@ -320,7 +320,7 @@ func (x *ButtonRequestType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ButtonRequestType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{4}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{4}
 }
 
 // *
@@ -362,7 +362,7 @@ func (x *PinMatrixRequestType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (PinMatrixRequestType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{5}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{5}
 }
 
 // *
@@ -404,7 +404,7 @@ func (x *WordRequestType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WordRequestType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{6}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{6}
 }
 
 // *
@@ -454,7 +454,7 @@ func (x *FirmwareFeatures) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (FirmwareFeatures) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{7}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{7}
 }
 
 // *
@@ -493,7 +493,7 @@ func (x *SkycoinAddressType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (SkycoinAddressType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{8}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{8}
 }
 
 // *
@@ -519,7 +519,7 @@ func (m *HDNodeType) Reset()         { *m = HDNodeType{} }
 func (m *HDNodeType) String() string { return proto.CompactTextString(m) }
 func (*HDNodeType) ProtoMessage()    {}
 func (*HDNodeType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{0}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{0}
 }
 func (m *HDNodeType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -602,7 +602,7 @@ func (m *HDNodePathType) Reset()         { *m = HDNodePathType{} }
 func (m *HDNodePathType) String() string { return proto.CompactTextString(m) }
 func (*HDNodePathType) ProtoMessage()    {}
 func (*HDNodePathType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{1}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{1}
 }
 func (m *HDNodePathType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -669,7 +669,7 @@ func (m *CoinType) Reset()         { *m = CoinType{} }
 func (m *CoinType) String() string { return proto.CompactTextString(m) }
 func (*CoinType) ProtoMessage()    {}
 func (*CoinType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{2}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{2}
 }
 func (m *CoinType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -796,7 +796,7 @@ func (m *MultisigRedeemScriptType) Reset()         { *m = MultisigRedeemScriptTy
 func (m *MultisigRedeemScriptType) String() string { return proto.CompactTextString(m) }
 func (*MultisigRedeemScriptType) ProtoMessage()    {}
 func (*MultisigRedeemScriptType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{3}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{3}
 }
 func (m *MultisigRedeemScriptType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -870,7 +870,7 @@ func (m *TxInputType) Reset()         { *m = TxInputType{} }
 func (m *TxInputType) String() string { return proto.CompactTextString(m) }
 func (*TxInputType) ProtoMessage()    {}
 func (*TxInputType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{4}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{4}
 }
 func (m *TxInputType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -993,7 +993,7 @@ func (m *TxOutputType) Reset()         { *m = TxOutputType{} }
 func (m *TxOutputType) String() string { return proto.CompactTextString(m) }
 func (*TxOutputType) ProtoMessage()    {}
 func (*TxOutputType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{5}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{5}
 }
 func (m *TxOutputType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1087,7 +1087,7 @@ func (m *TxOutputBinType) Reset()         { *m = TxOutputBinType{} }
 func (m *TxOutputBinType) String() string { return proto.CompactTextString(m) }
 func (*TxOutputBinType) ProtoMessage()    {}
 func (*TxOutputBinType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{6}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{6}
 }
 func (m *TxOutputBinType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1160,7 +1160,7 @@ func (m *TransactionType) Reset()         { *m = TransactionType{} }
 func (m *TransactionType) String() string { return proto.CompactTextString(m) }
 func (*TransactionType) ProtoMessage()    {}
 func (*TransactionType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{7}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{7}
 }
 func (m *TransactionType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1276,7 +1276,7 @@ func (m *TxRequestDetailsType) Reset()         { *m = TxRequestDetailsType{} }
 func (m *TxRequestDetailsType) String() string { return proto.CompactTextString(m) }
 func (*TxRequestDetailsType) ProtoMessage()    {}
 func (*TxRequestDetailsType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{8}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{8}
 }
 func (m *TxRequestDetailsType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1349,7 +1349,7 @@ func (m *TxRequestSerializedType) Reset()         { *m = TxRequestSerializedType
 func (m *TxRequestSerializedType) String() string { return proto.CompactTextString(m) }
 func (*TxRequestSerializedType) ProtoMessage()    {}
 func (*TxRequestSerializedType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{9}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{9}
 }
 func (m *TxRequestSerializedType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1418,7 +1418,7 @@ func (m *IdentityType) Reset()         { *m = IdentityType{} }
 func (m *IdentityType) String() string { return proto.CompactTextString(m) }
 func (*IdentityType) ProtoMessage()    {}
 func (*IdentityType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{10}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{10}
 }
 func (m *IdentityType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1506,7 +1506,7 @@ func (m *SkycoinTransactionInput) Reset()         { *m = SkycoinTransactionInput
 func (m *SkycoinTransactionInput) String() string { return proto.CompactTextString(m) }
 func (*SkycoinTransactionInput) ProtoMessage()    {}
 func (*SkycoinTransactionInput) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{11}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{11}
 }
 func (m *SkycoinTransactionInput) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1566,7 +1566,7 @@ func (m *SkycoinTransactionOutput) Reset()         { *m = SkycoinTransactionOutp
 func (m *SkycoinTransactionOutput) String() string { return proto.CompactTextString(m) }
 func (*SkycoinTransactionOutput) ProtoMessage()    {}
 func (*SkycoinTransactionOutput) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_3b468024de05fa62, []int{12}
+	return fileDescriptor_types_5d66f0cbf7519489, []int{12}
 }
 func (m *SkycoinTransactionOutput) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -5625,9 +5625,9 @@ var (
 	ErrIntOverflowTypes   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("types.proto", fileDescriptor_types_3b468024de05fa62) }
+func init() { proto.RegisterFile("types.proto", fileDescriptor_types_5d66f0cbf7519489) }
 
-var fileDescriptor_types_3b468024de05fa62 = []byte{
+var fileDescriptor_types_5d66f0cbf7519489 = []byte{
 	// 2220 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x58, 0x4b, 0x6f, 0xdb, 0xca,
 	0xf5, 0x0f, 0x25, 0xd9, 0x96, 0x8e, 0x28, 0x7b, 0xcc, 0x3c, 0xcc, 0xdc, 0x38, 0x89, 0xe2, 0xe4,

--- a/vendor/github.com/skycoin/skycoin/src/util/logging/logger.go
+++ b/vendor/github.com/skycoin/skycoin/src/util/logging/logger.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"os"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -15,6 +16,11 @@ type Logger struct {
 // since logrus lacks a distinct critical field and does not have configurable log levels
 func (logger *Logger) Critical() logrus.FieldLogger {
 	return logger.WithField(logPriorityKey, logPriorityCritical)
+}
+
+// WithTime overrides time, used by logger.
+func (logger *Logger) WithTime(t time.Time) *logrus.Entry {
+	return logger.WithFields(logrus.Fields{}).WithTime(t)
 }
 
 // MasterLogger wraps logrus.Logger and is able to create new package-aware loggers


### PR DESCRIPTION
Fixes #148

Changes:
- Automatically handle messages collision between two commands. The device can continuously ask for external entropy and a success response for entropy ack is automatically handled to avoid collision.

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no