### PR TITLE
Fixes #157 Add passphrase flag to transactionSign

### DIFF
--- a/src/cli/transaction_sign.go
+++ b/src/cli/transaction_sign.go
@@ -50,6 +50,10 @@ func transactionSignCmd() gcli.Command {
 				Usage:  "Device type to send instructions to, hardware wallet (USB) or emulator.",
 				EnvVar: "DEVICE_TYPE",
 			},
+			gcli.BoolFlag{
+				Name:	"passphrase",
+				Usage:	"Indicate if passphrase is used on signing process. If the hardware-wallet not set passphrase then this flag is ignored.",
+			},
 		},
 		OnUsageError: onCommandUsageError(name),
 		Action: func(c *gcli.Context) {
@@ -59,6 +63,7 @@ func transactionSignCmd() gcli.Command {
 			coins := c.Int64Slice("coin")
 			hours := c.Int64Slice("hour")
 			addressIndex := c.IntSlice("addressIndex")
+			withPassphrase := c.Bool("passphrase")
 
 			device := skyWallet.NewDevice(skyWallet.DeviceTypeFromString(c.String("deviceType")))
 			if device == nil {
@@ -102,7 +107,7 @@ func transactionSignCmd() gcli.Command {
 				transactionOutputs = append(transactionOutputs, &transactionOutput)
 			}
 
-			msg, err := device.TransactionSign(transactionInputs, transactionOutputs)
+			msg, err := device.TransactionSign(transactionInputs, transactionOutputs,withPassphrase)
 			if err != nil {
 				log.Error(err)
 				return

--- a/src/skywallet/messages.go
+++ b/src/skywallet/messages.go
@@ -286,12 +286,13 @@ func MessageSignMessage(addressIndex int, message string) ([][64]byte, error) {
 }
 
 // MessageTransactionSign prepare MessageTransactionSign request
-func MessageTransactionSign(inputs []*messages.SkycoinTransactionInput, outputs []*messages.SkycoinTransactionOutput) ([][64]byte, error) {
+func MessageTransactionSign(inputs []*messages.SkycoinTransactionInput, outputs []*messages.SkycoinTransactionOutput, usePassphrase *bool) ([][64]byte, error) {
 	skycoinTransactionSignMessage := &messages.TransactionSign{
 		NbIn:           proto.Uint32(uint32(len(inputs))),
 		NbOut:          proto.Uint32(uint32(len(outputs))),
 		TransactionIn:  inputs,
 		TransactionOut: outputs,
+		UsePassphrase: usePassphrase,
 	}
 	log.Println(skycoinTransactionSignMessage)
 

--- a/src/skywallet/skywallet.go
+++ b/src/skywallet/skywallet.go
@@ -774,13 +774,13 @@ func (d *Device) SignMessage(addressIndex int, message string) (wire.Message, er
 }
 
 // TransactionSign Ask the device to sign a transaction using the given information.
-func (d *Device) TransactionSign(inputs []*messages.SkycoinTransactionInput, outputs []*messages.SkycoinTransactionOutput) (wire.Message, error) {
+func (d *Device) TransactionSign(inputs []*messages.SkycoinTransactionInput, outputs []*messages.SkycoinTransactionOutput, usePassphrase bool) (wire.Message, error) {
 	if err := d.Connect(); err != nil {
 		return wire.Message{}, err
 	}
 	defer d.Disconnect()
 
-	transactionSignChunks, err := MessageTransactionSign(inputs, outputs)
+	transactionSignChunks, err := MessageTransactionSign(inputs, outputs,&usePassphrase)
 	if err != nil {
 		return wire.Message{}, err
 	}


### PR DESCRIPTION
Fixes #157 

Changes:
- Add `--passphrase` flag to transactionSign command

Does this change need to mentioned in CHANGELOG.md?
yes

Requires changes in protobuff specs?
yes
related to PR skycoin/hardware-wallet-protob#64 for issue skycoin/hardware-wallet-protob#63

Requires testing
yes
