### PR TITLE
Fixed no output for device in bootloader mode

### DIFF
--- a/src/cli/wipe.go
+++ b/src/cli/wipe.go
@@ -61,7 +61,11 @@ func wipeCmd() gcli.Command {
 				return
 			}
 
-			fmt.Println(responseMsg)
+			if len(responseMsg) > 0 {
+				fmt.Println(responseMsg)
+			} else {
+				fmt.Println("Firmware was successfully wiped from the device")
+			}
 		},
 	}
 }


### PR DESCRIPTION
Fixes #10 

Changes:
- If wipe was done in bootloader mode, it will show, that firmware was wiped.

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no

Requires testing
no